### PR TITLE
chore: enforce module boundaries except for test suites

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,6 +27,12 @@
       "rules": { "@typescript-eslint/ban-ts-comment": "off" }
     },
     {
+      "files": ["*.spec.ts", "*.spec.tsx", "*.spec.js", "*.spec.jsx"],
+      "rules": {
+        "@nrwl/nx/enforce-module-boundaries": "off"
+      }
+    },
+    {
       "files": ["*.js", "*.jsx"],
       "extends": ["plugin:@nrwl/nx/javascript"],
       "rules": {}

--- a/libs/internal/console-driver/test-util/ng-package.json
+++ b/libs/internal/console-driver/test-util/ng-package.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../../../../node_modules/ng-packagr/ng-package.schema.json",
+  "dest": "../../../../dist/libs/internal/console-driver/test-util",
+  "lib": {
+    "entryFile": "src/index.ts"
+  }
+}

--- a/libs/internal/console-driver/test-util/package.json
+++ b/libs/internal/console-driver/test-util/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@ngworker/internal/console-driver/test-util",
+  "version": "0.0.0",
+  "dependencies": {
+    "tslib": "^2.3.0"
+  }
+}

--- a/libs/internal/console-driver/test-util/project.json
+++ b/libs/internal/console-driver/test-util/project.json
@@ -21,6 +21,5 @@
       }
     }
   },
-  "tags": ["type:test-util"],
-  "implicitDependencies": ["!ngworker-lumberjack"]
+  "tags": ["type:test-util"]
 }

--- a/libs/internal/console-driver/test-util/project.json
+++ b/libs/internal/console-driver/test-util/project.json
@@ -3,6 +3,22 @@
   "sourceRoot": "libs/internal/console-driver/test-util/src",
   "prefix": "ngworker",
   "targets": {
+    "build": {
+      "executor": "@nrwl/angular:ng-packagr-lite",
+      "outputs": ["dist/libs/internal/console-driver/test-util"],
+      "options": {
+        "project": "libs/internal/console-driver/test-util/ng-package.json"
+      },
+      "configurations": {
+        "production": {
+          "tsConfig": "libs/internal/console-driver/test-util/tsconfig.lib.prod.json"
+        },
+        "development": {
+          "tsConfig": "libs/internal/console-driver/test-util/tsconfig.lib.json"
+        }
+      },
+      "defaultConfiguration": "production"
+    },
     "test": {
       "executor": "@nrwl/jest:jest",
       "outputs": ["coverage/libs/internal/console-driver/test-util"],

--- a/libs/internal/console-driver/test-util/project.json
+++ b/libs/internal/console-driver/test-util/project.json
@@ -21,5 +21,6 @@
       }
     }
   },
-  "tags": ["type:test-util"]
+  "tags": ["type:test-util"],
+  "implicitDependencies": ["!ngworker-lumberjack"]
 }

--- a/libs/internal/console-driver/test-util/src/lib/noop-console/noop-console.module.ts
+++ b/libs/internal/console-driver/test-util/src/lib/noop-console/noop-console.module.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @nrwl/nx/enforce-module-boundaries */
 import { NgModule, Optional, SkipSelf } from '@angular/core';
 
 import { lumberjackConsoleToken } from '@ngworker/lumberjack/console-driver';

--- a/libs/internal/console-driver/test-util/src/lib/noop-console/noop-console.service.ts
+++ b/libs/internal/console-driver/test-util/src/lib/noop-console/noop-console.service.ts
@@ -1,8 +1,6 @@
-/* eslint-disable @nrwl/nx/enforce-module-boundaries */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Injectable } from '@angular/core';
-
 
 import { LumberjackConsole } from '@ngworker/lumberjack/console-driver';
 

--- a/libs/internal/console-driver/test-util/src/lib/spy-console/spy-console.module.ts
+++ b/libs/internal/console-driver/test-util/src/lib/spy-console/spy-console.module.ts
@@ -1,6 +1,5 @@
 import { NgModule, Optional, SkipSelf } from '@angular/core';
 
-// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
 import { lumberjackConsoleToken } from '@ngworker/lumberjack/console-driver';
 
 import { SpyConsole } from './spy-console.service';

--- a/libs/internal/console-driver/test-util/src/lib/spy-console/spy-console.service.ts
+++ b/libs/internal/console-driver/test-util/src/lib/spy-console/spy-console.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 
-// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
 import { LumberjackConsole } from '@ngworker/lumberjack/console-driver';
 
 /**

--- a/libs/internal/console-driver/test-util/tsconfig.json
+++ b/libs/internal/console-driver/test-util/tsconfig.json
@@ -12,12 +12,13 @@
   ],
   "compilerOptions": {
     "target": "es2020",
+    "types": ["jest", "node"],
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
+    "noFallthroughCasesInSwitch": true
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,

--- a/libs/internal/console-driver/test-util/tsconfig.lib.json
+++ b/libs/internal/console-driver/test-util/tsconfig.lib.json
@@ -4,8 +4,7 @@
     "outDir": "../../../../dist/out-tsc",
     "declaration": true,
     "declarationMap": true,
-    "inlineSources": true,
-    "types": ["jest", "node"]
+    "inlineSources": true
   },
   "exclude": ["src/test-setup.ts", "**/*.spec.ts", "**/*.test.ts"],
   "include": ["**/*.ts"]

--- a/libs/internal/console-driver/test-util/tsconfig.lib.prod.json
+++ b/libs/internal/console-driver/test-util/tsconfig.lib.prod.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.lib.json",
+  "compilerOptions": {
+    "declarationMap": false
+  },
+  "angularCompilerOptions": {}
+}

--- a/libs/internal/console-driver/test-util/tsconfig.spec.json
+++ b/libs/internal/console-driver/test-util/tsconfig.spec.json
@@ -2,8 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../../../dist/out-tsc",
-    "module": "commonjs",
-    "types": ["jest", "node"]
+    "module": "commonjs"
   },
   "files": ["src/test-setup.ts"],
   "include": ["jest.config.ts", "**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]

--- a/libs/internal/test-util/ng-package.json
+++ b/libs/internal/test-util/ng-package.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../../../node_modules/ng-packagr/ng-package.schema.json",
+  "dest": "../../../dist/libs/internal/test-util",
+  "lib": {
+    "entryFile": "src/index.ts"
+  }
+}

--- a/libs/internal/test-util/package.json
+++ b/libs/internal/test-util/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@ngworker/internal/test-util",
+  "version": "0.0.0",
+  "dependencies": {
+    "tslib": "^2.3.0"
+  }
+}

--- a/libs/internal/test-util/project.json
+++ b/libs/internal/test-util/project.json
@@ -34,6 +34,5 @@
       }
     }
   },
-  "tags": ["type:test-util"],
-  "implicitDependencies": ["!ngworker-lumberjack"]
+  "tags": ["type:test-util"]
 }

--- a/libs/internal/test-util/project.json
+++ b/libs/internal/test-util/project.json
@@ -14,12 +14,10 @@
     "lint": {
       "executor": "@nrwl/linter:eslint",
       "options": {
-        "lintFilePatterns": [
-          "libs/internal/test-util/**/*.ts",
-          "libs/internal/test-util/**/*.html"
-        ]
+        "lintFilePatterns": ["libs/internal/test-util/**/*.ts", "libs/internal/test-util/**/*.html"]
       }
     }
   },
-  "tags": ["type:test-util"]
+  "tags": ["type:test-util"],
+  "implicitDependencies": ["!ngworker-lumberjack"]
 }

--- a/libs/internal/test-util/project.json
+++ b/libs/internal/test-util/project.json
@@ -3,6 +3,22 @@
   "sourceRoot": "libs/internal/test-util/src",
   "prefix": "ngworker",
   "targets": {
+    "build": {
+      "executor": "@nrwl/angular:ng-packagr-lite",
+      "outputs": ["dist/libs/internal/test-util"],
+      "options": {
+        "project": "libs/internal/test-util/ng-package.json"
+      },
+      "configurations": {
+        "production": {
+          "tsConfig": "libs/internal/test-util/tsconfig.lib.prod.json"
+        },
+        "development": {
+          "tsConfig": "libs/internal/test-util/tsconfig.lib.json"
+        }
+      },
+      "defaultConfiguration": "production"
+    },
     "test": {
       "executor": "@nrwl/jest:jest",
       "outputs": ["coverage/libs/internal/test-util"],

--- a/libs/internal/test-util/src/lib/time/fake-time.service.ts
+++ b/libs/internal/test-util/src/lib/time/fake-time.service.ts
@@ -1,13 +1,12 @@
 import { Injectable } from '@angular/core';
 
-// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
 import { LumberjackTimeService } from '@ngworker/lumberjack';
 
 @Injectable()
 export class FakeTimeService extends LumberjackTimeService {
   private now = new Date();
 
- override getUnixEpochTicks(): number {
+  override getUnixEpochTicks(): number {
     return this.now.valueOf();
   }
   setTime(fakeNow: Date): void {

--- a/libs/internal/test-util/tsconfig.json
+++ b/libs/internal/test-util/tsconfig.json
@@ -12,6 +12,7 @@
   ],
   "compilerOptions": {
     "target": "es2020",
+    "types": ["jest", "node"],
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/internal/test-util/tsconfig.lib.json
+++ b/libs/internal/test-util/tsconfig.lib.json
@@ -4,8 +4,7 @@
     "outDir": "../../../dist/out-tsc",
     "declaration": true,
     "declarationMap": true,
-    "inlineSources": true,
-    "types": ["jest", "node"]
+    "inlineSources": true
   },
   "exclude": ["src/test-setup.ts", "**/*.spec.ts", "**/*.test.ts"],
   "include": ["**/*.ts"]

--- a/libs/internal/test-util/tsconfig.lib.prod.json
+++ b/libs/internal/test-util/tsconfig.lib.prod.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.lib.json",
+  "compilerOptions": {
+    "declarationMap": false
+  },
+  "angularCompilerOptions": {}
+}

--- a/libs/internal/test-util/tsconfig.spec.json
+++ b/libs/internal/test-util/tsconfig.spec.json
@@ -2,8 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
-    "module": "commonjs",
-    "types": ["jest", "node"]
+    "module": "commonjs"
   },
   "files": ["src/test-setup.ts"],
   "include": ["jest.config.ts", "**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]

--- a/libs/ngworker/lumberjack/console-driver/src/configuration-api.spec.ts
+++ b/libs/ngworker/lumberjack/console-driver/src/configuration-api.spec.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
 import { isClass } from '@internal/test-util';
 
 import { LumberjackConsoleDriverModule, LumberjackConsoleDriverRootModule } from './index';

--- a/libs/ngworker/lumberjack/console-driver/src/lib/configuration/lumberjack-console-driver-config.token.spec.ts
+++ b/libs/ngworker/lumberjack/console-driver/src/lib/configuration/lumberjack-console-driver-config.token.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 
-// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
 import { resolveDependency } from '@internal/test-util';
 import { LumberjackLevel, LumberjackLogDriverConfig, lumberjackLogDriverConfigToken } from '@ngworker/lumberjack';
 

--- a/libs/ngworker/lumberjack/console-driver/src/lib/configuration/lumberjack-console-driver.module.spec.ts
+++ b/libs/ngworker/lumberjack/console-driver/src/lib/configuration/lumberjack-console-driver.module.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 
-// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
 import { expectNgModuleToBeGuardedAgainstDirectImport, resolveDependency } from '@internal/test-util';
 import {
   lumberjackConfigToken,

--- a/libs/ngworker/lumberjack/console-driver/src/lib/console/lumberjack-console.token.spec.ts
+++ b/libs/ngworker/lumberjack/console-driver/src/lib/console/lumberjack-console.token.spec.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
 import { resolveDependency } from '@internal/test-util';
 
 import { lumberjackConsoleToken } from './lumberjack-console.token';

--- a/libs/ngworker/lumberjack/console-driver/src/lib/log-drivers/lumberjack-console.driver.spec.ts
+++ b/libs/ngworker/lumberjack/console-driver/src/lib/log-drivers/lumberjack-console.driver.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @nrwl/nx/enforce-module-boundaries */
 import { TestBed } from '@angular/core/testing';
 
 import { SpyConsole, SpyConsoleModule } from '@internal/console-driver/test-util';

--- a/libs/ngworker/lumberjack/console-driver/src/log-drivers-api.spec.ts
+++ b/libs/ngworker/lumberjack/console-driver/src/log-drivers-api.spec.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
 import { isClass } from '@internal/test-util';
 
 import { LumberjackConsoleDriver } from './index';

--- a/libs/ngworker/lumberjack/project.json
+++ b/libs/ngworker/lumberjack/project.json
@@ -41,6 +41,5 @@
       }
     }
   },
-  "tags": [],
-  "implicitDependencies": ["!internal-console-driver-test-util", "!internal-test-util"]
+  "tags": []
 }

--- a/libs/ngworker/lumberjack/project.json
+++ b/libs/ngworker/lumberjack/project.json
@@ -41,5 +41,6 @@
       }
     }
   },
-  "tags": []
+  "tags": [],
+  "implicitDependencies": ["!internal-console-driver-test-util", "!internal-test-util"]
 }

--- a/libs/ngworker/lumberjack/src/configuration-api.spec.ts
+++ b/libs/ngworker/lumberjack/src/configuration-api.spec.ts
@@ -1,6 +1,5 @@
 import { InjectionToken } from '@angular/core';
 
-// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
 import { isClass } from '@internal/test-util';
 
 import {

--- a/libs/ngworker/lumberjack/src/lib/configuration/lumberjack-http-driver.module.spec.ts
+++ b/libs/ngworker/lumberjack/src/lib/configuration/lumberjack-http-driver.module.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 
-// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
 import { expectNgModuleToBeGuardedAgainstDirectImport, resolveDependency } from '@internal/test-util';
 import {
   LumberjackConfigLevels,

--- a/libs/ngworker/lumberjack/src/lib/configuration/lumberjack.module.spec.ts
+++ b/libs/ngworker/lumberjack/src/lib/configuration/lumberjack.module.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 
-// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
 import { expectNgModuleToBeGuardedAgainstDirectImport, resolveDependency } from '@internal/test-util';
 
 import { isProductionEnvironmentToken } from '../environment/is-production-environment.token';

--- a/libs/ngworker/lumberjack/src/lib/formatting/format-log-driver-error.spec.ts
+++ b/libs/ngworker/lumberjack/src/lib/formatting/format-log-driver-error.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 
-// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
 import { NoopDriver, NoopDriverModule, resolveDependency } from '@internal/test-util';
 
 import { LumberjackModule } from '../configuration/lumberjack.module';

--- a/libs/ngworker/lumberjack/src/lib/formatting/lumberjack-format-log.spec.ts
+++ b/libs/ngworker/lumberjack/src/lib/formatting/lumberjack-format-log.spec.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
 import { resolveDependency } from '@internal/test-util';
 
 import { LumberjackLogFactory } from '../logging/lumberjack-log-factory';

--- a/libs/ngworker/lumberjack/src/lib/formatting/lumberjack-log-formatter.service.spec.ts
+++ b/libs/ngworker/lumberjack/src/lib/formatting/lumberjack-log-formatter.service.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 
-// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
 import { FakeTimeService, resolveDependency } from '@internal/test-util';
 
 import { LumberjackModule } from '../configuration/lumberjack.module';

--- a/libs/ngworker/lumberjack/src/lib/log-drivers/lumberjack-http.driver.spec.ts
+++ b/libs/ngworker/lumberjack/src/lib/log-drivers/lumberjack-http.driver.spec.ts
@@ -2,7 +2,6 @@ import { HttpClientTestingModule, HttpTestingController, TestRequest } from '@an
 import { TestBed } from '@angular/core/testing';
 import { VERSION } from '@angular/platform-browser';
 
-// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
 import { createCriticalDriverLog, createDriverLog, repeatSideEffect, resolveDependency } from '@internal/test-util';
 import {
   LumberjackLevel,

--- a/libs/ngworker/lumberjack/src/lib/log-drivers/lumberjack-log-driver-logger.spec.ts
+++ b/libs/ngworker/lumberjack/src/lib/log-drivers/lumberjack-log-driver-logger.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 
-// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
 import { resolveDependency, SpyDriver, SpyDriverModule } from '@internal/test-util';
 
 import { LumberjackModule } from '../configuration/lumberjack.module';

--- a/libs/ngworker/lumberjack/src/lib/logging/lumberjack-log-factory.spec.ts
+++ b/libs/ngworker/lumberjack/src/lib/logging/lumberjack-log-factory.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 
-// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
 import { FakeTimeService, resolveDependency } from '@internal/test-util';
 
 import { LumberjackLevel } from '../logs/lumberjack-level';

--- a/libs/ngworker/lumberjack/src/lib/logging/lumberjack-log.builder.spec.ts
+++ b/libs/ngworker/lumberjack/src/lib/logging/lumberjack-log.builder.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 
-// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
 import { FakeTimeService, resolveDependency } from '@internal/test-util';
 
 import { LumberjackLevel } from '../logs/lumberjack-level';

--- a/libs/ngworker/lumberjack/src/lib/logging/lumberjack-logger.builder.spec.ts
+++ b/libs/ngworker/lumberjack/src/lib/logging/lumberjack-logger.builder.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 
-// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
 import { FakeTimeService, resolveDependency } from '@internal/test-util';
 
 import { LumberjackModule } from '../configuration/lumberjack.module';

--- a/libs/ngworker/lumberjack/src/lib/logging/lumberjack-logger.service.spec.ts
+++ b/libs/ngworker/lumberjack/src/lib/logging/lumberjack-logger.service.spec.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
-// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
 import { FakeTimeService, resolveDependency } from '@internal/test-util';
 
 import { LumberjackModule } from '../configuration/lumberjack.module';

--- a/libs/ngworker/lumberjack/src/lib/logging/lumberjack.service.spec.ts
+++ b/libs/ngworker/lumberjack/src/lib/logging/lumberjack.service.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @nrwl/nx/enforce-module-boundaries */
 import { StaticProvider } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 

--- a/libs/ngworker/lumberjack/src/lib/logging/scoped-lumberjack-logger.service.spec.ts
+++ b/libs/ngworker/lumberjack/src/lib/logging/scoped-lumberjack-logger.service.spec.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
-// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
 import { FakeTimeService, resolveDependency } from '@internal/test-util';
 
 import { LumberjackModule } from '../configuration/lumberjack.module';

--- a/libs/ngworker/lumberjack/src/lib/time/lumberjack-time.service.spec.ts
+++ b/libs/ngworker/lumberjack/src/lib/time/lumberjack-time.service.spec.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
 import { resolveDependency } from '@internal/test-util';
 
 import { LumberjackTimeService } from './lumberjack-time.service';

--- a/libs/ngworker/lumberjack/src/logging-api.spec.ts
+++ b/libs/ngworker/lumberjack/src/logging-api.spec.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
 import { isClass } from '@internal/test-util';
 
 import { LumberjackLogFactory, LumberjackLogger, LumberjackService, ScopedLumberjackLogger } from './index';

--- a/libs/ngworker/lumberjack/src/logs-api.spec.ts
+++ b/libs/ngworker/lumberjack/src/logs-api.spec.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
 import { isObject } from '@internal/test-util';
 
 import {

--- a/libs/ngworker/lumberjack/src/time-api.spec.ts
+++ b/libs/ngworker/lumberjack/src/time-api.spec.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
 import { isClass } from '@internal/test-util';
 
 import { LumberjackTimeService } from './index';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

- Several comments disabling the `@nrwl/nx/enforce-module-boundaries` lint rule with no explanation
- `build` and/or `lint` targets fail

Closes #6
Closes #14

## What is the new behavior?
- No comments disabling the `@nrwl/nx/enforce-module-boundaries` lint rule
- The `@nrwl/nx/enforce-module-boundaries` rule is disabled for all test suites
- `build` and `lint` targets succeed
- `build` targets are added to the internal test utility libraries because buildable (and implicitly publishable) libraries such as `@ngworker/lumberjack` cannot depend on non-buildable libraries
- The dependency chain from `@ngworker/lumberjack` to test utilities is broken to allow building of test utility libraries

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information