### PR TITLE
test: ignore coverage of unused faked methods

### DIFF
--- a/libs/internal/test-util/src/lib/error-throwing-driver/error-throwing.driver.ts
+++ b/libs/internal/test-util/src/lib/error-throwing-driver/error-throwing.driver.ts
@@ -18,6 +18,7 @@ export class ErrorThrowingDriver implements LumberjackLogDriver {
 
   constructor(@Inject(errorThrowingDriverConfigToken) readonly config: ErrorThrowingDriverConfig) {}
 
+  /* istanbul ignore next */
   logCritical({ formattedLog }: LumberjackLogDriverLog): void {
     this.log(formattedLog);
   }
@@ -30,14 +31,17 @@ export class ErrorThrowingDriver implements LumberjackLogDriver {
     this.log(formattedLog);
   }
 
+  /* istanbul ignore next */
   logInfo({ formattedLog }: LumberjackLogDriverLog): void {
     this.log(formattedLog);
   }
 
+  /* istanbul ignore next */
   logTrace({ formattedLog }: LumberjackLogDriverLog): void {
     this.log(formattedLog);
   }
 
+  /* istanbul ignore next */
   logWarning({ formattedLog }: LumberjackLogDriverLog): void {
     this.log(formattedLog);
   }

--- a/libs/internal/test-util/src/lib/object-driver/object.driver.ts
+++ b/libs/internal/test-util/src/lib/object-driver/object.driver.ts
@@ -20,6 +20,7 @@ export class ObjectDriver implements LumberjackLogDriver<ObjectPayload> {
     private readonly objectService: ObjectService
   ) {}
 
+  /* istanbul ignore next */
   logCritical({ log }: LumberjackLogDriverLog<ObjectPayload>): void {
     this.objectService.log(log.payload);
   }
@@ -28,18 +29,22 @@ export class ObjectDriver implements LumberjackLogDriver<ObjectPayload> {
     this.objectService.log(log.payload);
   }
 
+  /* istanbul ignore next */
   logError({ log }: LumberjackLogDriverLog<ObjectPayload>): void {
     this.objectService.log(log.payload);
   }
 
+  /* istanbul ignore next */
   logInfo({ log }: LumberjackLogDriverLog<ObjectPayload>): void {
     this.objectService.log(log.payload);
   }
 
+  /* istanbul ignore next */
   logTrace({ log }: LumberjackLogDriverLog<ObjectPayload>): void {
     this.objectService.log(log.payload);
   }
 
+  /* istanbul ignore next */
   logWarning({ log }: LumberjackLogDriverLog<ObjectPayload>): void {
     this.objectService.log(log.payload);
   }

--- a/libs/internal/test-util/src/lib/spy-driver/spy.driver.ts
+++ b/libs/internal/test-util/src/lib/spy-driver/spy.driver.ts
@@ -31,6 +31,7 @@ export class SpyDriver<TPayload extends LumberjackLogPayload | void = void>
   /**
    * Reset tracking on spies.
    */
+  /* istanbul ignore next */
   reset(): void {
     this.logCritical.mockClear();
     this.logDebug.mockClear();


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Some unused methods of our mock objects are degrading the test coverage reports

## What is the new behavior?

The unused methods in the mock objects are ignored for the coverage reports.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```